### PR TITLE
Baseuri

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 		<meta charset=utf-8>
 		<title>sugar three.js</title>
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-		<base href="/sugar-sugar">
+		<base href="https://peterbreen.github.io/sugar-sugar">
 	</head>
 	<body>
 		<script src="/vendor/three.js"></script>

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<meta charset=utf-8>
+		<base href="https://peterbreen.github.io/sugar-sugar">
 		<title>sugar three.js</title>
     <link rel="stylesheet" type="text/css" href="/css/style.css">
-		<base href="https://peterbreen.github.io/sugar-sugar">
 	</head>
 	<body>
 		<script src="/vendor/three.js"></script>


### PR DESCRIPTION
Base URI now absolute path. This still works locally, but attempting to fix deploying to gh-pages.